### PR TITLE
feat: unified extraction of rivets lib & loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,10 +925,8 @@ dependencies = [
  "ctor",
  "dll-syringe",
  "mod_util",
- "semver",
  "thiserror",
  "windows",
- "zip",
 ]
 
 [[package]]
@@ -965,12 +963,6 @@ dependencies = [
  "quote",
  "syn 2.0.74",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -592,6 +592,16 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "lockfree-object-pool"
@@ -632,8 +642,8 @@ dependencies = [
 
 [[package]]
 name = "mod_util"
-version = "0.4.0"
-source = "git+https://github.com/fgardt/factorio-scanner#f7d01241649a088df3b81b75838a2a391de0eb0a"
+version = "0.4.1"
+source = "git+https://github.com/fgardt/factorio-scanner#3132a1827f18ab15775f8c8989ac643203da629e"
 dependencies = [
  "byteorder",
  "natord",
@@ -924,6 +934,7 @@ dependencies = [
  "configparser",
  "ctor",
  "dll-syringe",
+ "libloading",
  "mod_util",
  "thiserror",
  "windows",
@@ -966,18 +977,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.206"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.206"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -987,7 +998,7 @@ dependencies = [
 [[package]]
 name = "serde_helper"
 version = "0.1.0"
-source = "git+https://github.com/fgardt/factorio-scanner#f7d01241649a088df3b81b75838a2a391de0eb0a"
+source = "git+https://github.com/fgardt/factorio-scanner#3132a1827f18ab15775f8c8989ac643203da629e"
 dependencies = [
  "num",
  "serde",
@@ -1243,19 +1254,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -1268,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1278,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1291,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "widestring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,54 @@
 version = 3
 
 [[package]]
+name = "abi_stable"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6512d3eb05ffe5004c59c206de7f99c34951504056ce23fc953842f12c445"
+dependencies = [
+ "abi_stable_derive",
+ "abi_stable_shared",
+ "const_panic",
+ "core_extensions",
+ "crossbeam-channel",
+ "generational-arena",
+ "libloading 0.7.4",
+ "lock_api",
+ "parking_lot",
+ "paste",
+ "repr_offset",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "abi_stable_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7178468b407a4ee10e881bc7a328a65e739f0863615cca4429d43916b05e898"
+dependencies = [
+ "abi_stable_shared",
+ "as_derive_utils",
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "typed-arena",
+]
+
+[[package]]
+name = "abi_stable_shared"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b5df7688c123e63f4d4d649cba63f2967ba7f7861b1664fca3f77d3dad2b63"
+dependencies = [
+ "core_extensions",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +107,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "as_derive_utils"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3c96645900a44cf11941c111bd08a6573b0e2f9f69bc9264b179d8fae753c4"
+dependencies = [
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +144,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -191,6 +257,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_extensions"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c71dc07c9721607e7a16108336048ee978c3a8b129294534272e8bac96c0ee"
+dependencies = [
+ "core_extensions_proc_macros",
+]
+
+[[package]]
+name = "core_extensions_proc_macros"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f3b219d28b6e3b4ac87bc1fc522e0803ab22e055da177bff0068c4150c61a6"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -399,6 +489,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generational-arena"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "generic-array"
@@ -595,12 +694,32 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -779,6 +898,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "path-absolutize"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +1046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,17 +1084,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "repr_offset"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
+dependencies = [
+ "tstr",
+]
+
+[[package]]
 name = "rivets-injector"
 version = "1.0.2"
 dependencies = [
+ "abi_stable",
  "anyhow",
  "configparser",
  "ctor",
  "dll-syringe",
- "libloading",
+ "libloading 0.8.5",
  "mod_util",
  "thiserror",
  "windows",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -954,6 +1130,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -974,6 +1156,12 @@ dependencies = [
  "quote",
  "syn 2.0.74",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1063,7 +1251,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "itertools",
  "proc-macro2",
  "quote",
@@ -1075,6 +1263,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "stopwatch2"
@@ -1212,6 +1406,27 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "tstr"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8e0294f14baae476d0dd0a2d780b2e24d66e349a9de876f5126777a37bdba7"
+dependencies = [
+ "tstr_proc_macros",
+]
+
+[[package]]
+name = "tstr_proc_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "rivets-injector"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "abi_stable",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +57,18 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
@@ -106,6 +142,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets",
+]
 
 [[package]]
 name = "cipher"
@@ -207,7 +256,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -223,6 +307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -233,7 +318,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -255,7 +340,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -294,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +393,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
@@ -337,9 +434,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -348,6 +457,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core 0.52.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -360,13 +492,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -388,12 +538,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -466,6 +631,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mod_util"
+version = "0.4.0"
+source = "git+https://github.com/fgardt/factorio-scanner#f7d01241649a088df3b81b75838a2a391de0eb0a"
+dependencies = [
+ "byteorder",
+ "natord",
+ "petgraph",
+ "regex",
+ "serde",
+ "serde_helper",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tracing",
+ "zip",
+]
+
+[[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,10 +664,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_enum"
@@ -497,7 +759,7 @@ checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -533,6 +795,22 @@ dependencies = [
  "digest",
  "hmac",
 ]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.3.0",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pkg-config"
@@ -610,6 +888,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rivets-injector"
 version = "1.0.2"
 dependencies = [
@@ -617,11 +924,18 @@ dependencies = [
  "configparser",
  "ctor",
  "dll-syringe",
+ "mod_util",
  "semver",
  "thiserror",
  "windows",
  "zip",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -649,7 +963,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -660,22 +974,73 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.205"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
+checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.205"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
+checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "serde_helper"
+version = "0.1.0"
+source = "git+https://github.com/fgardt/factorio-scanner#f7d01241649a088df3b81b75838a2a391de0eb0a"
+dependencies = [
+ "num",
+ "serde",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.3.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -715,6 +1080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911ece10388afa48417f99e01df038460b6249a3ee0255f6446a6881b702fbb4"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -773,7 +1144,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -783,10 +1154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -794,6 +1167,48 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"
@@ -833,6 +1248,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "widestring"
@@ -877,7 +1346,16 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
  "windows-targets",
 ]
 
@@ -902,7 +1380,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -913,7 +1391,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1026,7 +1504,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1046,7 +1524,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1065,7 +1543,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap",
+ "indexmap 2.3.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lints.clippy]
 nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
+unwrap_used = "warn"
+expect_used = "allow"
+trivial_regex = "allow"
 
 [dependencies]
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.86"
 semver = "1.0.23"
 thiserror = "1.0.63"
 configparser = "3.1.0"
+mod_util = { git = "https://github.com/fgardt/factorio-scanner" }
 
 [target.'cfg(windows)'.dependencies]
 zip = "2.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivets-injector"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ windows = { version = "0.58.0", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
+abi_stable = "0.11.3"
 ctor = "0.2"
 libloading = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,12 @@ nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [dependencies]
-anyhow = "1.0.86"
-semver = "1.0.23"
-thiserror = "1.0.63"
-configparser = "3.1.0"
+thiserror = "1.0"
+configparser = "3.1"
 mod_util = { git = "https://github.com/fgardt/factorio-scanner" }
 
 [target.'cfg(windows)'.dependencies]
-zip = "2.1.6"
+anyhow = "1.0"
 dll-syringe = "0.15.2"
 windows = { version = "0.58.0", features = [
     "Win32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ windows = { version = "0.58.0", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
-ctor = "0.2.8"
+ctor = "0.2"
+libloading = "0.8"
 
 [lib]
 crate-type = ["cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "rivets-injector"
 version = "1.0.2"
 edition = "2021"
 
+[lints.clippy]
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
 [dependencies]
 anyhow = "1.0.86"
 semver = "1.0.23"

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use std::{
 
 use configparser::ini::Ini;
 use mod_util::{
-    mod_list::{self, ModList, ModListError},
+    mod_list::{ModList, ModListError},
     mod_loader::ModError,
 };
 
@@ -151,4 +151,20 @@ pub fn extract_rivets_lib(
     std::fs::write(&lib_path, lib)?;
 
     Ok(lib_path)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BinFolderError {
+    #[error("Failed to get binary path: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Failed to get binary folder")]
+    BinFolder,
+}
+
+pub fn get_bin_folder() -> Result<PathBuf, BinFolderError> {
+    std::env::current_exe()?
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .ok_or(BinFolderError::BinFolder)
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -137,7 +137,8 @@ pub fn extract_rivets_lib(
     #[cfg(target_os = "windows")]
     static RIVETS_LIB: &str = "rivets.dll";
 
-    let mod_list = ModList::generate_custom(read_data, &write_data)?;
+    let mut mod_list = ModList::generate_custom(read_data, &write_data)?;
+    mod_list.load()?;
 
     let Some(rivets) = mod_list.load_mod("rivets")? else {
         return Err(ExtractError::RivetsNotEnabled);

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,10 @@ use std::{
 };
 
 use configparser::ini::Ini;
+use mod_util::{
+    mod_list::{self, ModList, ModListError},
+    mod_loader::ModError,
+};
 
 struct CfgFile {
     map: HashMap<String, String>,
@@ -104,7 +108,47 @@ pub fn get_data_dirs(bin_path: impl AsRef<Path>) -> Result<(PathBuf, PathBuf), C
         .ok_or(ConfigError::MissingKey("write-data".to_string()))?;
 
     Ok((
-        resolve_path(&read_path, &bin_path)?,
-        resolve_path(&write_path, bin_path)?,
+        resolve_path(&read_path, &bin_path)?.canonicalize()?,
+        resolve_path(&write_path, bin_path)?.canonicalize()?,
     ))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExtractError {
+    #[error("{0}")]
+    ModList(#[from] ModListError),
+
+    #[error("{0}")]
+    Mod(#[from] ModError),
+
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Rivets is not enabled")]
+    RivetsNotEnabled,
+}
+
+pub fn extract_rivets_lib(
+    read_data: impl AsRef<Path>,
+    write_data: impl AsRef<Path>,
+) -> Result<PathBuf, ExtractError> {
+    #[cfg(target_os = "linux")]
+    static RIVETS_LIB: &str = "rivets.so";
+    #[cfg(target_os = "windows")]
+    static RIVETS_LIB: &str = "rivets.dll";
+
+    let mod_list = ModList::generate_custom(read_data, &write_data)?;
+
+    let Some(rivets) = mod_list.load_mod("rivets")? else {
+        return Err(ExtractError::RivetsNotEnabled);
+    };
+
+    let lib = rivets.get_file(RIVETS_LIB)?;
+
+    std::fs::create_dir_all(write_data.as_ref().join("temp/rivets"))?;
+
+    let lib_path = write_data.as_ref().join("temp/rivets").join(RIVETS_LIB);
+    std::fs::write(&lib_path, lib)?;
+
+    Ok(lib_path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,5 @@ mod linux;
 #[cfg(target_os = "linux")]
 #[ctor::ctor]
 fn main() {
-    linux::run()
+    linux::run();
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,14 +1,12 @@
 use crate::common;
 
 pub fn run() {
-    let Ok(bin_path) = std::env::current_exe() else {
-        eprintln!("Failed to get binary path");
-        return;
-    };
-
-    let Some(bin_folder) = bin_path.parent() else {
-        eprintln!("Failed to get binary folder");
-        return;
+    let bin_folder = match common::get_bin_folder() {
+        Ok(folder) => folder,
+        Err(e) => {
+            eprintln!("{e}");
+            return;
+        }
     };
 
     let (read_data, write_data) = match common::get_data_dirs(bin_folder) {

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -35,7 +35,7 @@ pub fn run() {
         };
 
         let entry_point: libloading::Symbol<unsafe extern "C" fn()> =
-            match lib.get(b"rivets_entry_point") {
+            match lib.get(b"rivets_entry_point\0") {
                 Ok(entry_point) => entry_point,
                 Err(e) => {
                     eprintln!("Failed to get rivets entry point: {e}");

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,3 +1,31 @@
+use crate::common;
+
 pub fn run() {
-    println!("Hello, world!");
+    let Ok(bin_path) = std::env::current_exe() else {
+        eprintln!("Failed to get binary path");
+        return;
+    };
+
+    let Some(bin_folder) = bin_path.parent() else {
+        eprintln!("Failed to get binary folder");
+        return;
+    };
+
+    let (read_data, write_data) = match common::get_data_dirs(bin_folder) {
+        Ok(dirs) => dirs,
+        Err(e) => {
+            eprintln!("Failed to get data directories: {e}");
+            return;
+        }
+    };
+
+    let rivets_lib = match common::extract_rivets_lib(&read_data, &write_data) {
+        Ok(lib) => lib,
+        Err(e) => {
+            eprintln!("Failed to extract rivets library: {e}");
+            return;
+        }
+    };
+
+    // TODO: load rivets library
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,3 +1,5 @@
+use abi_stable::std_types::{ROption, RString};
+
 use crate::common;
 
 pub fn run() {
@@ -34,15 +36,20 @@ pub fn run() {
             }
         };
 
-        let entry_point: libloading::Symbol<unsafe extern "C" fn()> =
-            match lib.get(b"rivets_entry_point\0") {
-                Ok(entry_point) => entry_point,
+        let setup: libloading::Symbol<extern "C" fn(RString, RString) -> ROption<RString>> =
+            match lib.get(b"rivetslib_setup\0") {
+                Ok(setup) => setup,
                 Err(e) => {
-                    eprintln!("Failed to get rivets entry point: {e}");
+                    eprintln!("Failed to get rivetslib entry point: {e}");
                     return;
                 }
             };
 
-        entry_point();
+        if let ROption::RSome(err) = setup(
+            read_data.to_string_lossy().into(),
+            write_data.to_string_lossy().into(),
+        ) {
+            eprintln!("{err}");
+        }
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -25,5 +25,24 @@ pub fn run() {
         }
     };
 
-    // TODO: load rivets library
+    unsafe {
+        let lib = match libloading::Library::new(rivets_lib) {
+            Ok(lib) => lib,
+            Err(e) => {
+                eprintln!("Failed to load rivets library: {e}");
+                return;
+            }
+        };
+
+        let entry_point: libloading::Symbol<unsafe extern "C" fn()> =
+            match lib.get(b"rivets_entry_point") {
+                Ok(entry_point) => entry_point,
+                Err(e) => {
+                    eprintln!("Failed to get rivets entry point: {e}");
+                    return;
+                }
+            };
+
+        entry_point();
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,4 +9,5 @@ fn main() -> anyhow::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
+#[allow(clippy::missing_const_for_fn)]
 fn main() {}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,12 +1,10 @@
 //! A small windows application to inject the Rivets DLL into Factorio.
 
 use crate::common;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use dll_syringe::process::{BorrowedProcess, ProcessModule};
 use dll_syringe::{process::OwnedProcess, Syringe};
 use std::ffi::CString;
-use std::fs;
-use std::fs::File;
 use std::io;
 use std::os::windows::io::FromRawHandle;
 use std::path::{Path, PathBuf};
@@ -53,7 +51,7 @@ fn rpc(
             "payload_procedure",
         )
     }?
-    .ok_or(anyhow!("Failed to get RPC procedure"))?;
+    .ok_or_else(|| anyhow!("Failed to get RPC procedure"))?;
     match rpc.call(
         &read_path.as_ref().to_path_buf(),
         &write_path.as_ref().to_path_buf(),
@@ -63,6 +61,7 @@ fn rpc(
     }
 }
 
+#[allow(clippy::cast_possible_truncation)]
 fn create_pipe() -> Result<(HANDLE, HANDLE)> {
     let mut stdout_read = INVALID_HANDLE_VALUE;
     let mut stdout_write = INVALID_HANDLE_VALUE;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -119,7 +119,7 @@ pub fn run() -> Result<()> {
     println!("Factorio path: {factorio_path:?}");
     let factorio_path = PCSTR(factorio_path.as_ptr().cast());
 
-    let dll_path = common::extract_rivets_lib(read_path, write_path)?;
+    let dll_path = common::extract_rivets_lib(&read_path, &write_path)?;
 
     let factorio_process_information: PROCESS_INFORMATION = start_factorio(factorio_path)?;
     println!("Factorio process started.");

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -48,7 +48,7 @@ fn rpc(
     let rpc = unsafe {
         syringe.get_payload_procedure::<fn(PathBuf, PathBuf) -> Option<String>>(
             module,
-            "payload_procedure",
+            "rivetslib_setup",
         )
     }?
     .ok_or_else(|| anyhow!("Failed to get RPC procedure"))?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,7 +4,6 @@ use crate::common;
 use anyhow::{anyhow, bail, Context, Result};
 use dll_syringe::process::{BorrowedProcess, ProcessModule};
 use dll_syringe::{process::OwnedProcess, Syringe};
-use semver::Version;
 use std::ffi::CString;
 use std::fs;
 use std::fs::File;
@@ -21,89 +20,6 @@ use windows::Win32::System::Threading::{
     CreateProcessA, ResumeThread, TerminateProcess, CREATE_SUSPENDED, PROCESS_INFORMATION,
     STARTUPINFOA,
 };
-use zip::read::ZipArchive;
-
-fn unzip_specific_file(
-    file_name: &str,
-    zip_path: impl AsRef<Path>,
-    output_path: impl AsRef<Path>,
-) -> Result<()> {
-    let file = File::open(zip_path)?;
-    let mut archive = ZipArchive::new(file).context("Failed to open rivets mod ZIP archive")?;
-
-    let mut zip_file = archive
-        .by_name(file_name)
-        .context("Failed to find rivets.dll in ZIP archive")?;
-
-    let err = format!(
-        "Failed to create output file {}",
-        output_path
-            .as_ref()
-            .to_str()
-            .ok_or(anyhow!("Failed to unzip rivets.dll"))?
-    );
-    let mut output_file = File::create(output_path).context(err)?;
-
-    io::copy(&mut zip_file, &mut output_file)
-        .context("Failed to write ZIP entry to output file")?;
-
-    Ok(())
-}
-
-fn find_latest_rivets_version(write_path: impl AsRef<Path>) -> Result<String> {
-    let mut latest_version: Option<Version> = None;
-    let mut latest_version_file: Option<PathBuf> = None;
-
-    for entry in fs::read_dir(write_path.as_ref().join("mods"))? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        if let Some(file_name_str) = file_name.to_str() {
-            if file_name_str.starts_with("rivets_") && file_name_str.ends_with(".zip") {
-                let version_str = file_name_str
-                    .trim_start_matches("rivets_")
-                    .trim_end_matches(".zip");
-                if let Ok(version) = Version::parse(version_str) {
-                    if let Some(current_version) = &latest_version {
-                        if version > *current_version {
-                            latest_version = Some(version);
-                            latest_version_file = Some(entry.path());
-                        }
-                    } else {
-                        latest_version = Some(version);
-                        latest_version_file = Some(entry.path());
-                    }
-                }
-            }
-        }
-    }
-
-    if let Some(file_path) = latest_version_file {
-        if let Some(file_name) = file_path.file_name() {
-            if let Some(file_name_str) = file_name.to_str() {
-                return Ok(file_name_str.to_string());
-            }
-        }
-    }
-
-    Err(anyhow!("No rivets mod found in the mods folder"))
-}
-
-fn extract_dll(write_path: impl AsRef<Path>) -> Result<PathBuf> {
-    const DLL_NAME: &str = "rivets/rivets.dll";
-
-    let latest_rivets_version = find_latest_rivets_version(write_path.as_ref())?;
-    println!("Found rivets version: {latest_rivets_version} Injecting...",);
-
-    let tmp_folder = write_path.as_ref().join("temp/rivets");
-    fs::create_dir_all(&tmp_folder)?;
-
-    let output_path = tmp_folder.join(format!("{latest_rivets_version}.dll"));
-    let zip_path = write_path.as_ref().join("mods").join(latest_rivets_version);
-
-    unzip_specific_file(DLL_NAME, zip_path, &output_path)?;
-
-    Ok(output_path)
-}
 
 fn get_syringe() -> Result<Syringe> {
     let Some(process) = OwnedProcess::find_first_by_name("factorio") else {
@@ -191,19 +107,19 @@ fn start_factorio(factorio_path: PCSTR) -> Result<PROCESS_INFORMATION> {
 }
 
 pub fn run() -> Result<()> {
-    let mut factorio_path = std::env::current_dir()?;
-    let (read_path, write_path) = common::get_data_dirs(&factorio_path)?;
+    let bin_path = common::get_bin_folder()?;
+    let (read_path, write_path) = common::get_data_dirs(&bin_path)?;
 
     let (stdout_read, _) = create_pipe()?;
     let mut reader = unsafe { std::fs::File::from_raw_handle(stdout_read.0) };
 
-    factorio_path.push("factorio.exe");
+    let factorio_path = bin_path.join("factorio.exe");
 
     let factorio_path = CString::new(factorio_path.as_os_str().to_string_lossy().into_owned())?;
     println!("Factorio path: {factorio_path:?}");
     let factorio_path = PCSTR(factorio_path.as_ptr().cast());
 
-    let dll_path = extract_dll(&write_path)?;
+    let dll_path = common::extract_rivets_lib(read_path, write_path)?;
 
     let factorio_process_information: PROCESS_INFORMATION = start_factorio(factorio_path)?;
     println!("Factorio process started.");


### PR DESCRIPTION
Adds common functions to load the `rivets` mod and retrieve the contained binary for the corresponding platform.

Also implements the loading of the lib binary on https://github.com/factorio-rivets/rivets-injector/labels/os%3A%3Alinux.