### PR TITLE
Feat/change windows injector to inject all mods instead of just librivets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "as_derive_utils"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -270,6 +287,15 @@ name = "core_extensions_proc_macros"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f3b219d28b6e3b4ac87bc1fc522e0803ab22e055da177bff0068c4150c61a6"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -467,6 +493,12 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fixedbitset"
@@ -681,6 +713,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576c8060ecfdf2e56995cf3274b4f2d71fa5e4fa3607c1c0b63c10180ee58741"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efb9e65d4503df81c615dc33ff07042a9408ac7f26b45abee25566f7fbfd12c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +765,16 @@ checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets",
+]
+
+[[package]]
+name = "libudis86-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139bbf9ddb1bfc90c1ac64dd2923d9c957cd433cee7315c018125d72ab08a6b0"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -745,6 +810,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +831,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mmap-fixed-fixed"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0681853891801e4763dc252e843672faf32bcfee27a0aa3b19733902af450acc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -782,6 +866,12 @@ name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "ntapi"
@@ -955,6 +1045,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdb"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
+dependencies = [
+ "fallible-iterator",
+ "scroll",
+ "uuid",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,12 +1185,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "repr_offset"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
 dependencies = [
  "tstr",
+]
+
+[[package]]
+name = "retour"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9af44d40e2400b44d491bfaf8eae111b09f23ac4de6e92728e79d93e699c527"
+dependencies = [
+ "cfg-if",
+ "generic-array",
+ "libc",
+ "libudis86-sys",
+ "mmap-fixed-fixed",
+ "once_cell",
+ "region",
+ "slice-pool2",
+]
+
+[[package]]
+name = "rivets"
+version = "0.1.0"
+dependencies = [
+ "abi_stable",
+ "retour",
+ "rivets-macros",
+ "rivets-shared",
 ]
 
 [[package]]
@@ -1103,7 +1242,35 @@ dependencies = [
  "dll-syringe",
  "libloading 0.8.5",
  "mod_util",
+ "rivets",
  "thiserror",
+ "windows",
+]
+
+[[package]]
+name = "rivets-macros"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "darling",
+ "lazy-regex",
+ "proc-macro2",
+ "quote",
+ "rivets-shared",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "rivets-shared"
+version = "0.1.0"
+dependencies = [
+ "abi_stable",
+ "anyhow",
+ "cpp_demangle",
+ "pdb",
+ "serde",
+ "syn 2.0.74",
+ "undname",
  "windows",
 ]
 
@@ -1263,6 +1430,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "slice-pool2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3d689654af89bdfeba29a914ab6ac0236d382eb3b764f7454dde052f2821f8"
 
 [[package]]
 name = "smallvec"
@@ -1450,10 +1623,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
+name = "undname"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f76889af53deca091b038f6ebb04efa45fcba08908e69c0049e8b8c281f16f9"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.6.0",
+ "bstr",
+ "bumpalo",
+ "nonmax",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "version_check"
@@ -1550,7 +1744,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1629,6 +1823,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
  "windows-targets",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ mod_util = { git = "https://github.com/fgardt/factorio-scanner" }
 
 [target.'cfg(windows)'.dependencies]
 anyhow = "1.0"
-dll-syringe = "0.15.2"
+dll-syringe = "0.15"
 windows = { version = "0.58.0", features = [
     "Win32",
     "Win32_System_Threading",
     "Win32_System_Pipes",
     "Win32_Security",
 ] }
+rivets = { git = "https://github.com/factorio-rivets/rivets-rs" }
 
 [target.'cfg(unix)'.dependencies]
 abi_stable = "0.11.3"

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,9 +1,12 @@
 //! A small windows application to inject the Rivets DLL into Factorio.
 
 use crate::common;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use dll_syringe::process::{BorrowedProcess, ProcessModule};
 use dll_syringe::{process::OwnedProcess, Syringe};
+use mod_util::mod_list::ModList;
+use mod_util::mod_loader::ModError;
+use rivets::SymbolCache;
 use std::ffi::CString;
 use std::io;
 use std::os::windows::io::FromRawHandle;
@@ -39,20 +42,19 @@ fn inject_dll(
 fn rpc(
     syringe: &Syringe,
     module: ProcessModule<BorrowedProcess>,
-    read_path: impl AsRef<Path>,
-    write_path: impl AsRef<Path>,
+    symbol_cache: &SymbolCache,
 ) -> Result<()> {
-    let rpc = unsafe {
-        syringe.get_payload_procedure::<fn(PathBuf, PathBuf) -> Option<String>>(
-            module,
-            "rivetslib_setup",
-        )
-    }?
-    .ok_or_else(|| anyhow!("Failed to get RPC procedure"))?;
-    match rpc.call(
-        &read_path.as_ref().to_path_buf(),
-        &write_path.as_ref().to_path_buf(),
-    )? {
+    type Rpc = fn(symbol_cache: SymbolCache) -> Option<String>;
+
+    let rpc = unsafe { syringe.get_payload_procedure::<Rpc>(module, "rivets_finalize") }
+        .context("Failed to get RPC procedure")?
+        .ok_or_else(|| {
+            anyhow!("Failed to get RPC procedure. rivets_finalize does not exist in rivets.dll")
+        })?;
+
+    println!("RPC procedure address located.");
+
+    match rpc.call(symbol_cache).context("RPC paniced")? {
         Some(err) => bail!(format!("Failed to preform RPC: {err}")),
         None => Ok(()),
     }
@@ -102,20 +104,84 @@ fn start_factorio(factorio_path: PCSTR) -> Result<PROCESS_INFORMATION> {
     Ok(factorio_process_information)
 }
 
-pub fn run() -> Result<()> {
-    let bin_path = common::get_bin_folder()?;
-    let (read_path, write_path) = common::get_data_dirs(&bin_path)?;
+fn extract_all_mods_libs(
+    read_data: impl AsRef<Path>,
+    write_data: impl AsRef<Path>,
+) -> Result<Vec<(String, PathBuf)>> {
+    #[cfg(target_os = "linux")]
+    static DYNAMIC_LIBRARY_SUFFIX: &str = ".so";
+    #[cfg(target_os = "linux")]
+    static RIVETS_LIB: &str = "rivets.so";
+    #[cfg(target_os = "windows")]
+    static DYNAMIC_LIBRARY_SUFFIX: &str = ".dll";
+    #[cfg(target_os = "windows")]
+    static RIVETS_LIB: &str = "rivets.dll";
 
-    let (stdout_read, _) = create_pipe()?;
+    let mut result = vec![];
+    let mut mod_list = ModList::generate_custom(&read_data, &write_data)
+        .context("Failed to find your Factorio mods directory.")?;
+    mod_list.load().context(
+        "Failed to parse mods-list.json file. Please ensure this file exists and is well-formated.",
+    )?;
+
+    let (all_active_mods, mod_load_order) = mod_list.active_with_order();
+    for mod_name in mod_load_order {
+        let current_mod = all_active_mods
+            .get(&mod_name)
+            .expect("The list of active mods contains all mods in the load order");
+
+        let lib = match current_mod.get_file(RIVETS_LIB) {
+            Err(ModError::PathDoesNotExist(_)) => continue,
+            Err(ModError::ZipError(e))
+                if e.to_string() == "specified file not found in archive" =>
+            {
+                continue
+            }
+            Ok(lib) => lib,
+            Err(e) => return Err(anyhow!(e).context(format!("Detected corrupted mod file! {mod_name} does not have proper zip encodings. Please try to reinstall this mod."))),
+        };
+
+        std::fs::create_dir_all(write_data.as_ref().join("temp/rivets")).context(
+            "Could not find the factorio/temp directory. Please manually create this directory.",
+        )?;
+
+        let extracted_lib_name = format!("{mod_name}{DYNAMIC_LIBRARY_SUFFIX}");
+        let lib_path = write_data
+            .as_ref()
+            .join("temp/rivets")
+            .join(extracted_lib_name);
+        std::fs::write(&lib_path, lib)
+            .context("Failed to write the extracted rivets .dll library to the temp directory.")?;
+
+        result.push((mod_name, lib_path));
+    }
+
+    Ok(result)
+}
+
+pub fn run() -> Result<()> {
+    println!("Starting Rivets injector...");
+    let bin_path = common::get_bin_folder().context("Failed to find factorio.exe. You must run this program from the Factorio installation directory.")?;
+    let (read_path, write_path) = common::get_data_dirs(&bin_path).context("Failed to parse Factorio's config-path.cfg and config.ini files. Please ensure these files actually exist. If not, reinstall Factorio.")?;
+
+    println!("Searching for Rivets mod .dll libraries...");
+    let all_mods = extract_all_mods_libs(read_path, write_path)?;
+    println!(
+        "Mods list loaded successfully. Found {} enabled rivets mods.",
+        all_mods.len()
+    );
+
+    let (stdout_read, _) = create_pipe().context(
+        "Failed to create operating system pipes. Try running rivets with elevated permissions.",
+    )?;
     let mut reader = unsafe { std::fs::File::from_raw_handle(stdout_read.0) };
 
     let factorio_path = bin_path.join("factorio.exe");
+    let pdb_path = bin_path.join("factorio.pdb");
 
-    let factorio_path = CString::new(factorio_path.as_os_str().to_string_lossy().into_owned())?;
+    let factorio_path = CString::new(factorio_path.as_os_str().to_string_lossy().into_owned()).context("Failed to convert Factorio path to CString. Do you have any invalid chars in your Factorio path? Please report this on the Rivets Github.")?;
     println!("Factorio path: {factorio_path:?}");
     let factorio_path = PCSTR(factorio_path.as_ptr().cast());
-
-    let dll_path = common::extract_rivets_lib(&read_path, &write_path)?;
 
     let factorio_process_information: PROCESS_INFORMATION = start_factorio(factorio_path)?;
     println!("Factorio process started.");
@@ -123,21 +189,31 @@ pub fn run() -> Result<()> {
         attempt_kill_factorio(factorio_process_information);
     })?;
 
-    println!("Injecting DLL into Factorio process...");
-    println!("\t{}", dll_path.display());
-
-    let module = inject_dll(&syringe, &dll_path).inspect_err(|_| {
+    let symbol_cache = SymbolCache::new(pdb_path, "factorio.exe").inspect_err(|_| {
         attempt_kill_factorio(factorio_process_information);
-    })?;
+    }).context("Failed to create symbol cache.")?;
 
-    println!("DLL injected successfully.");
-    println!("Performing DLL initialization RPC...");
+    for (mod_name, dll_path) in all_mods {
+        println!("Discovered rivets mod: {mod_name}");
+        println!("Injecting DLL into Factorio process...");
 
-    rpc(&syringe, module, read_path, write_path).inspect_err(|_| {
-        attempt_kill_factorio(factorio_process_information);
-    })?;
+        let module = inject_dll(&syringe, &dll_path)
+            .inspect_err(|_| {
+                attempt_kill_factorio(factorio_process_information);
+            })
+            .context(format!("DLL injection failed for {mod_name}"))?;
 
-    println!("RPC completed successfully.");
+        println!("DLL injected successfully. Performing DLL initialization RPC...");
+
+        rpc(&syringe, module, &symbol_cache)
+            .inspect_err(|_| {
+                attempt_kill_factorio(factorio_process_information);
+            })
+            .context(format!("Function detouring failed for {mod_name}"))?;
+
+        println!("RPC completed successfully.");
+    }
+
     println!("Returning control back into Factorio process...");
 
     unsafe {
@@ -153,8 +229,5 @@ pub fn run() -> Result<()> {
 }
 
 fn attempt_kill_factorio(factorio_process_information: PROCESS_INFORMATION) {
-    if let Err(e) = unsafe { TerminateProcess(factorio_process_information.hProcess, 0) } {
-        eprintln!("Failed to terminate Factorio process after experiencing a rivets error: {e}");
-        eprintln!("You likely have a ghost Factorio process running. Please kill it manually via task manager.");
-    }
+    let _ = unsafe { TerminateProcess(factorio_process_information.hProcess, 0) };
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -179,6 +179,10 @@ pub fn run() -> Result<()> {
     let factorio_path = bin_path.join("factorio.exe");
     let pdb_path = bin_path.join("factorio.pdb");
 
+    println!("Creating symbol cache...");
+    let symbol_cache = SymbolCache::new(pdb_path, "factorio.exe");
+    let symbol_cache = symbol_cache.context("Failed to create symbol cache.")?;
+
     let factorio_path = CString::new(factorio_path.as_os_str().to_string_lossy().into_owned()).context("Failed to convert Factorio path to CString. Do you have any invalid chars in your Factorio path? Please report this on the Rivets Github.")?;
     println!("Factorio path: {factorio_path:?}");
     let factorio_path = PCSTR(factorio_path.as_ptr().cast());
@@ -188,12 +192,6 @@ pub fn run() -> Result<()> {
     let syringe = get_syringe().inspect_err(|_| {
         attempt_kill_factorio(factorio_process_information);
     })?;
-
-    let symbol_cache = SymbolCache::new(pdb_path, "factorio.exe")
-        .inspect_err(|_| {
-            attempt_kill_factorio(factorio_process_information);
-        })
-        .context("Failed to create symbol cache.")?;
 
     for (mod_name, dll_path) in all_mods {
         println!("Discovered rivets mod: {mod_name}");

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -189,9 +189,11 @@ pub fn run() -> Result<()> {
         attempt_kill_factorio(factorio_process_information);
     })?;
 
-    let symbol_cache = SymbolCache::new(pdb_path, "factorio.exe").inspect_err(|_| {
-        attempt_kill_factorio(factorio_process_information);
-    }).context("Failed to create symbol cache.")?;
+    let symbol_cache = SymbolCache::new(pdb_path, "factorio.exe")
+        .inspect_err(|_| {
+            attempt_kill_factorio(factorio_process_information);
+        })
+        .context("Failed to create symbol cache.")?;
 
     for (mod_name, dll_path) in all_mods {
         println!("Discovered rivets mod: {mod_name}");


### PR DESCRIPTION
I made some changes to the design of librivets on windows. It turns out that if you try to inject a dll from inside an injected dll then windows will attach the grandfather dll to the child dll and not factorio.exe
From there, factorio is free to delete it from the temp folder and factorio crashes whenever a detour is invoked from the deleted file.
The end result is that I'm now instead injecting all mods from `rivets-injector`
